### PR TITLE
Build multiple versions of the documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,14 @@
 name: "Build and deploy documentation to GitHub Pages"
 
+# Because we build the docs for multiple versions, this workflow should be
+# triggered when pushing to *any* branch (not just master).defaults:
+# Except the branches that begin with `wip/`, because they are not ready
+# and will not be included in the docs anyway.
 on:
   push:
-    branches: [master, doc]
+    branches:
+      - '**'
+      - "!wip/*"
 
 permissions:
   contents: read
@@ -25,25 +31,29 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       # Get the source code
+      # (We need to specify the depth to 0 to get all branches and tags)
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       # Install the (source code, not docs) dependencies (requirements.txt)
       # This is required to build the docs, as we import the source code
       - name: Install source code dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      # Build the HTML docs; we need to `cd` first to correctly import packages
+      # Install the docs dependencies
       - name: Install docs dependencies
         run: |
           if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
+      # Build the HTML docs; we need to `cd` first to correctly import packages
       - name: Build docs with Sphinx
-        run: cd docs && make -e html
+        run: cd docs && make -e multiversion
       # Upload the docs as an artifact (required for deploying to Pages)
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: "docs/build/html"
+          path: "docs/build/html-mv"
       # Deploy the artifact (built docs) to Pages
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,6 +17,23 @@ help:
 preview:
 	sphinx-reload --build-dir "$(BUILDDIR)" .
 
+# Build docs for multiple versions (based on Git branches and tags).
+# The result is placed in `build/html-mv` (for "multiversion"), with each
+# version getting its own sub-directory inside it.
+# Additionally, we place a small fake index.html that simply redirects clients
+# to the latest stable version found. If no version can be found, the build aborts.
+multiversion:
+	sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)/html-mv"
+	# Find the tag with the highest version (latest "stable")
+	latest=$$(ls -1 "$(BUILDDIR)/html-mv" | grep 'v[0-9]' | sort --reverse --version-sort | head -n 1) ;\
+	latest=$${latest%/} ;\
+	if [ -z "$$latest" ]; then \
+	  echo 'ERROR: Cannot find latest version in tags. Aborting...' && exit 1 ;\
+	else \
+	  echo "Found latest version: $$latest ; creating redirect..."; \
+	  sed "s/{{ version }}/$$latest/g" redirect_to_version.html > "$(BUILDDIR)/html-mv/index.html" ;\
+	fi
+
 # Also remove the `source/modules` directory, which is built by autosummary.
 superclean: clean
 	rm -r "$(SOURCEDIR)/modules"

--- a/docs/redirect_to_version.html
+++ b/docs/redirect_to_version.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!--
+  This file is used to automatically redirect clients to one of the versions,
+  which are actually stored in subdirectories when using sphinx-multiversion.
+  (In other words, the root folder contains only the subdirectories for each
+  version, no .html file, and especially not the `index.html` landing page.)
+
+  This file MUST be rendered, e.g., as a Jinja2 template, or modified through
+  sed, to specify the correct version that we want to redirect to.
+  This can be, for example, the latest tag found, or hard-coding the master
+  branch. The corresponding folder (that we redirect to) MUST exist.
+  Otherwise, the redirection will NOT WORK, and GitHub Pages will show a
+  404 error.
+-->
+<title>Redirecting to latest documentation</title>
+<meta http-equiv="refresh" content="0; URL=./{{ version }}/index.html">
+<link rel="canonical" href="https://ethicsai.github.io/ethical-smart-grid/{{ version }}/index.html">

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 furo
 sphinx-copybutton
+sphinx-multiversion
 matplotlib
 myst-nb

--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -1,0 +1,33 @@
+{% if versions %}
+<details class="sidebar-versions sidebar-tree">
+  <summary>Select a version (v: {{ current_version.name }})</summary>
+  <p class="caption" role="heading">
+     <span class="caption-text">Branches (dev features)</span>
+  </p>
+  <ul>
+    {%- for item in versions.branches %}
+      <li class="toctree-l1">
+        {% if item.name == current_version.name %}
+          <b><a class="reference internal" href="{{ item.url }}">{{ item.name }}</a></b>
+        {% else %}
+          <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+        {% endif %}
+      </li>
+    {%- endfor %}
+  </ul>
+  <p class="caption" role="heading">
+     <span class="caption-text">Released versions</span>
+  </p>
+  <ul>
+    {%- for item in versions.tags | reverse %}
+      <li class="toctree-l1">
+        {% if item.name == current_version.name %}
+          <b><a class="reference internal" href="{{ item.url }}">{{ item.name }}</a></b>
+        {% else %}
+          <a class="reference internal" href="{{ item.url }}">{{ item.name }}</a>
+        {% endif %}
+      </li>
+    {%- endfor %}
+  </ul>
+</details>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,8 @@ extensions = [
     'myst_nb',
     # Add a link to the source code on each of the "API pages"
     'sphinx.ext.viewcode',
+    # Render the docs for multiple versions (tags, branches, ...)
+    'sphinx_multiversion',
 ]
 
 # Enable autosummary
@@ -68,6 +70,31 @@ intersphinx_mapping = {
 rst_epilog = '.. |project_name| replace:: {}'.format(project)
 
 
+# -- Options for Sphinx-multiversion
+
+# Whitelist pattern for tags (in our case, versions)
+# We ignore explicitly `v1.1.0-joss-paper` because it was used for Zenodo, it
+# is not a "real" version.
+smv_tag_whitelist = r'^(?!v1.1.0-joss-paper).*$'
+
+# Accept all branches except:
+# - `paper` specifically (only holds the JOSS paper's source)
+#    (note: the `$` is at the end of `paper` so that it matches this exact
+#     string; anything other, e.g. `papers`, can pass)
+# - any `wip/**` branch (because they are not ready)
+smv_branch_whitelist = r'^(?!wip/|paper$).*'
+
+# Allow remote branches from `origin` only (required for building all branches
+# on GitHub Actions, because they are not automatically fetched).
+smv_remote_whitelist = r'^origin$'
+
+# A version is considered "released" only if it is a tag beginning with `v`.
+smv_released_pattern = r'^tags/v.*$'
+
+# Each version gets a subdir based on its name (e.g., `master`, `v1.0.0`, ...)
+smv_outputdir_format = '{ref.name}'
+
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -79,3 +106,19 @@ html_theme = 'furo'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Override Furo's default sidebar widgets to add our version selector
+# At some point we should be able to use `variant-selector`, when Furo will add
+# support for versions.
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "versioning.html",  # Our custom template
+        "sidebar/navigation.html",
+        "sidebar/ethical-ads.html",
+        "sidebar/variant-selector.html",
+        "sidebar/scroll-end.html",
+    ]
+}


### PR DESCRIPTION
This PR allows building multiple versions of the documentation, based on the Git tags and branches.
A separate version is created for each of the branches and tags, which allows:

- browsing the docs for a previous tagged release (e.g., v1.0.0, v1.1.0, ...);
- browsing the docs for unreleased features (e.g., master, argumentation, ...).